### PR TITLE
Add parsing for U64 and I64 types

### DIFF
--- a/esp32nvs.py
+++ b/esp32nvs.py
@@ -362,12 +362,12 @@ def parse_nvs_entries(entries, entry_state_bitmap):
             entry_data["entry_data"] = data
 
         elif(nvs_types[entry_type] == "U64"):
-            data = struct.unpack("<i", data[0:4])[0]
+            data = struct.unpack("<Q", data[0:8])[0]
             entry_data["entry_data_type"] = "U64"
             entry_data["entry_data"] = data
 
         elif(nvs_types[entry_type] == "I64"):
-            data = struct.unpack("<i", data[0:4])[0]
+            data = struct.unpack("<q", data[0:8])[0]
             entry_data["entry_data_type"] = "I64"
             entry_data["entry_data"] = data
 

--- a/esp32nvs.py
+++ b/esp32nvs.py
@@ -144,6 +144,18 @@ def dump_nvs_entries(entries, entry_state_bitmap, fpos):
             entry_data["entry_data_type"] = "I32"
             entry_data["entry_data"] = data
 
+        elif(nvs_types[entry_type] == "U64"):
+            data = struct.unpack("<Q", data[0:8])[0]
+            print("      Data (U64) : 0x{:08x}".format(data))
+            entry_data["entry_data_type"] = "U64"
+            entry_data["entry_data"] = data
+        
+        elif(nvs_types[entry_type] == "I64"):
+            data = struct.unpack("<q", data[0:8])[0]
+            print("      Data (I64) : 0x{:08x}".format(data))
+            entry_data["entry_data_type"] = "I64"
+            entry_data["entry_data"] = data
+
         elif(nvs_types[entry_type] == "STR"):
             str_size = struct.unpack("<H", data[0:2])[0]
 

--- a/esp32nvs.py
+++ b/esp32nvs.py
@@ -361,6 +361,16 @@ def parse_nvs_entries(entries, entry_state_bitmap):
             entry_data["entry_data_type"] = "I32"
             entry_data["entry_data"] = data
 
+        elif(nvs_types[entry_type] == "U64"):
+            data = struct.unpack("<i", data[0:4])[0]
+            entry_data["entry_data_type"] = "U64"
+            entry_data["entry_data"] = data
+
+        elif(nvs_types[entry_type] == "I64"):
+            data = struct.unpack("<i", data[0:4])[0]
+            entry_data["entry_data_type"] = "I64"
+            entry_data["entry_data"] = data
+
         elif(nvs_types[entry_type] == "STR"):
             str_size = struct.unpack("<H", data[0:2])[0]
             entry_data["entry_data_type"] = "STR"
@@ -408,6 +418,7 @@ def parse_nvs_entries(entries, entry_state_bitmap):
 
         entries_out.append(entry_data)
         i += 1
+
     return entries_out
 
 


### PR DESCRIPTION
esp32nvs.py was missing handling for U64 and I64 types — added them in